### PR TITLE
Allow owners to remove servers or change addresses on reload

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/conf/BungeeConfiguration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/BungeeConfiguration.java
@@ -11,12 +11,15 @@ import java.util.UUID;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
 import lombok.Getter;
+
+import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ProxyConfig;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.util.CaseInsensitiveMap;
 import net.md_5.bungee.util.CaseInsensitiveSet;
 
@@ -97,18 +100,31 @@ public abstract class BungeeConfiguration implements ProxyConfig
             servers = new CaseInsensitiveMap<>( newServers );
         } else
         {
-            for ( ServerInfo oldServer : servers.values() )
-            {
-                // Don't allow servers to be removed
-                Preconditions.checkArgument( newServers.containsKey( oldServer.getName() ), "Server %s removed on reload!", oldServer.getName() );
-            }
+            Map<String, ServerInfo> oldServers = this.servers;
+            this.servers = new CaseInsensitiveMap<>(newServers);
 
-            // Add new servers
-            for ( Map.Entry<String, ServerInfo> newServer : newServers.entrySet() )
+            for ( ServerInfo oldServer : oldServers.values() )
             {
-                if ( !servers.containsValue( newServer.getValue() ) )
-                {
-                    servers.put( newServer.getKey(), newServer.getValue() );
+                ServerInfo newServer = newServers.get(oldServer.getName());
+                if (newServer == null || !oldServer.getAddress().equals(newServer.getAddress())) {
+                    BungeeCord.getInstance().getLogger().info("Moving players off of server: " + oldServer.getName());
+                    // The server is being removed, or having it's address changed
+                    for (ProxiedPlayer player : oldServer.getPlayers()) {
+                        ListenerInfo listener = player.getPendingConnection().getListener();
+                        String destinationName = newServers.get(listener.getDefaultServer()) == null ? listener.getDefaultServer() : listener.getFallbackServer();
+                        ServerInfo destination = newServers.get(destinationName);
+                        if (destination == null) {
+                            BungeeCord.getInstance().getLogger().severe("Couldn't find server " + listener.getDefaultServer() + " or " + listener.getFallbackServer() + " to put player " + player.getName() + " on");
+                            player.disconnect(BungeeCord.getInstance().getTranslation("fallback_kick", "Not found on reload"));
+                            continue;
+                        }
+                        player.connect(destination, (success, cause) -> {
+                            if (!success) {
+                                BungeeCord.getInstance().getLogger().log(Level.WARNING, "Failed to connect " + player.getName() + " to " + destination.getName(), cause);
+                                player.disconnect(BungeeCord.getInstance().getTranslation("fallback_kick", cause.getCause().getClass().getName()));
+                            }
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #17

Moves all players on the removed server to the default server.
Address changes also move the players to the default server.
Kicks players on failure to move.

The functionality of this PR is currently untested.
Someday I'll get another test server to play with.

I'd like someone (potentially me) to test this, and then i'll manually rebase.
