### PR TITLE
Edit messages without modifying the JAR file

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -129,6 +129,11 @@ public abstract class ProxyServer
     public abstract void setConfigurationAdapter(ConfigurationAdapter adapter);
 
     /**
+     * Reload the proxy server messages from the configuration file.
+     */
+    public abstract void reloadMessages();
+
+    /**
      * Get the currently in use reconnect handler.
      *
      * @return the in use reconnect handler

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -31,7 +31,11 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.util.ResourceLeakDetector;
 import net.md_5.bungee.conf.Configuration;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.text.MessageFormat;
@@ -43,6 +47,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Properties;
+import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -147,6 +153,7 @@ public class BungeeCord extends ProxyServer
     private ConnectionThrottle joinThrottle;
     private final ModuleManager moduleManager = new ModuleManager();
 
+    private final File messagesFile = new File( "messages.properties" );
     
     {
         // TODO: Proper fallback when we interface the manager
@@ -212,6 +219,57 @@ public class BungeeCord extends ProxyServer
             {
                 logger.info( "Using standard Java compressor. To enable zero copy compression, run on 64 bit Linux" );
             }
+        }
+
+        reloadMessages();
+    }
+
+    @Override
+    public void reloadMessages()
+    {
+        try // Make sure the translation file is up to date
+        {
+            Properties messages = new Properties();
+
+            if ( messagesFile.exists() )
+            {
+                try ( InputStream is = new FileInputStream( messagesFile ) )
+                {
+                    messages.load( is );
+                }
+            }
+
+            // Check for new entries
+            int newEntries = 0;
+            for ( String key : bundle.keySet() )
+            {
+                if ( !messages.containsKey( key ) )
+                {
+                    messages.put( key, bundle.getObject(key) );
+                    newEntries++;
+                }
+            }
+
+            if ( newEntries > 0 )
+            {
+                // We need to save the file to add the new entries
+                try ( OutputStream os = new FileOutputStream( messagesFile ) )
+                {
+                    messages.store( os, "BungeeCord messages, last updated for " + getVersion() );
+                }
+            }
+        } catch ( Exception ex )
+        {
+            getLogger().log( Level.SEVERE, "Could not update messages", ex );
+        }
+
+        // Load the messages from the configuration file
+        try ( InputStream is = new FileInputStream( messagesFile ) )
+        {
+            bundle = new PropertyResourceBundle( is );
+        } catch ( Exception ex )
+        {
+            getLogger().log( Level.SEVERE, "Could not reload messages", ex );
         }
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
@@ -18,6 +18,7 @@ public class CommandReload extends Command
     public void execute(CommandSender sender, String[] args)
     {
         BungeeCord.getInstance().config.load();
+        BungeeCord.getInstance().reloadMessages();
         BungeeCord.getInstance().stopListeners();
         BungeeCord.getInstance().startListeners();
         BungeeCord.getInstance().getPluginManager().callEvent( new ProxyReloadEvent( sender ) );


### PR DESCRIPTION
I made this long ago for BungeeCord (see SpigotMC/BungeeCord#1187) but it was never merged. This PR adds a new file created by BungeeCord: `messages.properties` which is essentially mostly just a copy of the file included in the JAR allowing the user to modify it more easily without touching the JAR file.

Maybe this can help you, it's probably not perfect but @kashike asked me to make this PR so I've updated it and rebased it on Waterfall's master.
