### PR TITLE
Improve performance of message translations

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -535,7 +535,9 @@ public class BungeeCord extends ProxyServer
         String translation = "<translation '" + name + "' missing>";
         try
         {
-            translation = MessageFormat.format( bundle.getString( name ), args );
+            String string = bundle.getString( name );
+            
+            translation = args.length == 0 ? string : MessageFormat.format( string, args );
         } catch ( MissingResourceException ex )
         {
         }


### PR DESCRIPTION
MessageFormat#format will look to replace the pattern with the arguments provided regardless of array length, however a lot of the translations in BungeeCord do not require an argument so by testing the array length we can reduce object creation and remove unnecessary logic.
